### PR TITLE
Fixed an issue with stopping the JettyComponent

### DIFF
--- a/src/net/thegeez/w3a/components/server.clj
+++ b/src/net/thegeez/w3a/components/server.clj
@@ -93,7 +93,7 @@
     (log/info :msg "Stopping jetty component")
     (when-let [server (:server component)]
       (http/stop (:server server)))
-    (dissoc component :server)))
+    (assoc component :server nil)))
 
 (defn jetty-component []
   (map->JettyComponent {}))


### PR DESCRIPTION
JettyComponent record was converted to an ordinary Clojure map when the predefined :server field was dissoc'ed from it.
